### PR TITLE
Do not explicitely require flowplayer

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ The plugin can be used in a [browserify](http://browserify.org) and/or
 
 ```js
 var flowplayer = require('flowplayer');
-require('flowplayer-hlsjs'); // Plugin injects itself to flowplayer
+var engine = require('flowplayer-hlsjs');
+engine(flowplayer);
 
 flowplayer('#container', {
   clip: {

--- a/flowplayer.hlsjs.js
+++ b/flowplayer.hlsjs.js
@@ -618,4 +618,4 @@ var extension = function (Hls, flowplayer) {
 
 };
 if (typeof module === 'object' && module.exports) module.exports = extension.bind(undefined, require('hls.js'));
-else if (window.flowplayer) extension(window.flowplayer, window.Hls);
+else if (window.Hls && window.flowplayer) extension(window.Hls, window.flowplayer);

--- a/flowplayer.hlsjs.js
+++ b/flowplayer.hlsjs.js
@@ -23,7 +23,7 @@
 
 */
 
-(function (flowplayer, Hls) {
+var extension = function (Hls, flowplayer) {
     "use strict";
     var engineName = "hlsjs",
         hlsconf,
@@ -616,6 +616,6 @@
         });
     }
 
-}.apply(null, (typeof module === 'object' && module.exports)
-    ? [require('flowplayer'), require('hls.js')]
-    : [window.flowplayer, window.Hls]));
+};
+if (typeof module === 'object' && module.exports) module.exports = extension.bind(undefined, require('hls.js'));
+else if (window.flowplayer) extension(window.flowplayer, window.Hls);

--- a/flowplayer.hlsjs.js
+++ b/flowplayer.hlsjs.js
@@ -617,5 +617,8 @@ var extension = function (Hls, flowplayer) {
     }
 
 };
-if (typeof module === 'object' && module.exports) module.exports = extension.bind(undefined, require('hls.js'));
-else if (window.Hls && window.flowplayer) extension(window.Hls, window.flowplayer);
+if (typeof module === 'object' && module.exports) {
+    module.exports = extension.bind(undefined, require('hls.js'));
+} else if (window.Hls && window.flowplayer) {
+    extension(window.Hls, window.flowplayer);
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "jslint --edition=latest --devel flowplayer.hlsjs.js",
-    "build": "webpack"
+    "build": "webpack",
+    "dev": "webpack --progress --colors --watch"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This allows us to inject in example a commercial version of the player

This is similar to https://github.com/flowplayer/flowplayer-quality-selector/pull/9