### PR TITLE
guard for missing clip

### DIFF
--- a/flowplayer.hlsjs.js
+++ b/flowplayer.hlsjs.js
@@ -33,7 +33,7 @@
                 return typ.toLowerCase().indexOf("mpegurl") > -1;
             },
             hlsQualitiesSupport = function (conf) {
-                var hlsQualities = conf.clip.hlsQualities || conf.hlsQualities;
+                var hlsQualities = (conf.clip && conf.clip.hlsQualities) || conf.hlsQualities;
 
                 return support.inlineVideo &&
                         (hlsQualities === true ||


### PR DESCRIPTION
this passes it onto `flowplayer` to handle and throw an error, instead of the hls.js engine handling it.