### PR TITLE
Provide buffer value as third argument

### DIFF
--- a/flowplayer.hlsjs.js
+++ b/flowplayer.hlsjs.js
@@ -402,7 +402,7 @@
                                                 }
                                             } catch (ignore) {}
                                             video.buffer = buffer;
-                                            arg = e;
+                                            arg = buffer;
                                             break;
                                         case "finish":
                                             if (hls.autoLevelEnabled && (loop || conf.playlist.length < 2 || conf.advance === false)) {


### PR DESCRIPTION
The fix for flowplayer/flowplayer#1047 expects the `buffer` event to send the buffer value as third argument to the handler.

If there's no specific reason to send the `Event` object as third argument, then we should do this like this.