### PR TITLE
Listen to ID3 metadata events

### DIFF
--- a/flowplayer.hlsjs.js
+++ b/flowplayer.hlsjs.js
@@ -602,7 +602,20 @@
                                             maxLevel = hls.loadLevel;
                                         }
                                         break;
-
+                                    case "FRAG_PARSING_METADATA":
+                                        data.samples.forEach(function(sample) {
+                                          var metadataHandler = function() {
+                                            if (videoTag.currentTime < sample.dts) return;
+                                            videoTag.removeEventListener('timeupdate', metadataHandler);
+                                            var raw = new TextDecoder('utf-8').decode(sample.data);
+                                            player.trigger('metadata', [player, {
+                                              key: raw.substr(10, 4),
+                                              data: raw.substr(21)
+                                            }]);
+                                          };
+                                          videoTag.addEventListener('timeupdate', metadataHandler);
+                                        });
+                                        break;
                                     case "ERROR":
                                         if (data.fatal || hlsUpdatedConf.strict) {
                                             switch (data.type) {

--- a/flowplayer.hlsjs.js
+++ b/flowplayer.hlsjs.js
@@ -1,4 +1,6 @@
 /*jslint browser: true, for: true, node: true */
+/*eslint indent: ["error", 4], no-empty: ["error", { "allowEmptyCatch": true }] */
+/*eslint-disable quotes, no-console */
 /*global window */
 
 /*!
@@ -426,13 +428,13 @@
                                                     bean.one(videoTag, (loop
                                                         ? "play."
                                                         : "timeupdate.") + engineName, function () {
-                                                        var currentLevel = hls.currentLevel;
+                                                            var currentLevel = hls.currentLevel;
 
-                                                        if (currentLevel < maxLevel) {
-                                                            hls.currentLevel = maxLevel;
-                                                            setReplayLevel = true;
-                                                        }
-                                                    });
+                                                            if (currentLevel < maxLevel) {
+                                                                hls.currentLevel = maxLevel;
+                                                                setReplayLevel = true;
+                                                            }
+                                                        });
                                                 }
                                             }
                                             break;
@@ -604,16 +606,16 @@
                                         break;
                                     case "FRAG_PARSING_METADATA":
                                         data.samples.forEach(function(sample) {
-                                          var metadataHandler = function() {
-                                            if (videoTag.currentTime < sample.dts) return;
-                                            videoTag.removeEventListener('timeupdate', metadataHandler);
-                                            var raw = new TextDecoder('utf-8').decode(sample.data);
-                                            player.trigger('metadata', [player, {
-                                              key: raw.substr(10, 4),
-                                              data: raw.substr(21)
-                                            }]);
-                                          };
-                                          videoTag.addEventListener('timeupdate', metadataHandler);
+                                            var metadataHandler = function() {
+                                                if (videoTag.currentTime < sample.dts) return;
+                                                videoTag.removeEventListener('timeupdate', metadataHandler);
+                                                var raw = new TextDecoder('utf-8').decode(sample.data);
+                                                player.trigger('metadata', [player, {
+                                                    key: raw.substr(10, 4),
+                                                    data: raw.substr(21)
+                                                }]);
+                                            };
+                                            videoTag.addEventListener('timeupdate', metadataHandler);
                                         });
                                         break;
                                     case "ERROR":

--- a/flowplayer.hlsjs.js
+++ b/flowplayer.hlsjs.js
@@ -608,14 +608,14 @@
                                         data.samples.forEach(function(sample) {
                                             var metadataHandler = function() {
                                                 if (videoTag.currentTime < sample.dts) return;
-                                                videoTag.removeEventListener('timeupdate', metadataHandler);
+                                                bean.off(videoTag, 'timeupdate.' + engineName, metadataHandler);
                                                 var raw = new TextDecoder('utf-8').decode(sample.data);
                                                 player.trigger('metadata', [player, {
                                                     key: raw.substr(10, 4),
                                                     data: raw.substr(21)
                                                 }]);
                                             };
-                                            videoTag.addEventListener('timeupdate', metadataHandler);
+                                            bean.on(videoTag, 'timeupdate.' + engineName, metadataHandler);
                                         });
                                         break;
                                     case "ERROR":


### PR DESCRIPTION
The upcoming FP7 release will have support for parsing ID3 metadata from
HLS streams, both in HTML5 engine and flashls.

It will trigger the `metadata` event on the player.

This commit adds support for that to HLS.js engine.

Also closes #34