### PR TITLE
Use HLSJS build instead of building here

### DIFF
--- a/flowplayer.hlsjs.js
+++ b/flowplayer.hlsjs.js
@@ -809,7 +809,7 @@
 
     };
     if (typeof module === 'object' && module.exports) {
-        module.exports = extension.bind(undefined, require('hls.js/lib/index.js'));
+        module.exports = extension.bind(undefined, require('hls.js'));
     } else if (window.Hls && window.flowplayer) {
         extension(window.Hls, window.flowplayer);
     }

--- a/package.json
+++ b/package.json
@@ -21,18 +21,13 @@
   },
   "homepage": "https://github.com/flowplayer/flowplayer-hlsjs",
   "dependencies": {
-    "hls.js": "0.6.11",
-    "webworkify-webpack": "^1.0.4"
+    "hls.js": "0.6.11"
   },
   "peerDependencies": {
     "flowplayer": "^6.0.3"
   },
   "devDependencies": {
-    "babel-core": "^6.5.1",
-    "babel-loader": "^6.2.2",
-    "babel-preset-es2015": "^6.5.0",
     "jslint": "^0.9.5",
-    "url-toolkit": "^1.0.4",
     "webpack": "^1.12.13",
     "wrapper-webpack-plugin": "^0.1.7"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -37,11 +37,6 @@ module.exports = {
   externals: {
     flowplayer: 'flowplayer'
   },
-  module: {
-    loaders: [
-      { test: /\/hls\.js\/.+/, loader: 'babel', query: { presets: ['es2015'] } }
-    ]
-  },
   output: {
     path: path.join(__dirname, 'dist'),
     filename: '[name].js'

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -48,7 +48,6 @@ module.exports = {
       mangle: true,
       output: { comments: false }
     }),
-    new webpack.NormalModuleReplacementPlugin(/^webworkify$/, 'webworkify-webpack'),
     new WrapperPlugin({header: headerComment, footer: footerComment}),
     new webpack.BannerPlugin(banner, {raw: true})
   ]


### PR DESCRIPTION
It only adds 2kb to the minified build and means you won't need to keep track of hlsjs's dependencies and keep adding them here too.